### PR TITLE
Refresh homepage content; shorten it; add nav submenus

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,29 +4,11 @@
   <div class="wrap hero-inner">
     <div class="kicker">● DOE · Office of Science · ASCR</div>
     <h1 class="display">Stewarding the scientific software <span class="accent">stack</span></h1>
-    <p class="lede">PESO partners with DOE labs, universities, vendors, and the open-source community to keep scientific computing software correct, current, and built on solid ground — from hardware up.</p>
+    <p class="lede">PESO exists to preserve, sustain, and advance the investments made by the DOE Exascale Computing Project in a robust, versatile, and portable HPC software ecosystem — and the people who make that ecosystem effective. Partnership with CASS.</p>
+    <p style="margin-top:14px; font-size:13.5px; color:#8296B4;">PIs: Michael Heroux &amp; Lois Curfman McInnes</p>
     <div class="hero-ctas">
       <a class="btn-primary" href="/connect">Connect with PESO</a>
       <a class="btn-ghost" href="/thrusts">View the six thrusts</a>
-    </div>
-
-    <div class="stack">
-      <div class="stack-row">
-        <div class="stack-label">Applications</div>
-        <div class="stack-bar">DOE mission science codes, national lab workloads</div>
-      </div>
-      <div class="stack-row">
-        <div class="stack-label">Libraries &amp; Tools</div>
-        <div class="stack-bar">CASS community, HPC math libraries, dev &amp; QA tooling</div>
-      </div>
-      <div class="stack-row">
-        <div class="stack-label">Delivery Layer</div>
-        <div class="stack-bar">E4S + Spack</div>
-      </div>
-      <div class="stack-row">
-        <div class="stack-label">Hardware Platforms</div>
-        <div class="stack-bar">CPU, GPU, exascale systems</div>
-      </div>
     </div>
   </div>
 </header>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -4,12 +4,77 @@
       <img src="/images/peso-logo-no-bg.png" alt="PESO">
       <span>PESO</span>
     </a>
-    <div class="navlinks">
-      <a href="/about"{% if page.url == '/about' or page.url == '/about/team' %} class="active"{% endif %}>About</a>
-      <a href="/thrusts"{% if page.url == '/thrusts' %} class="active"{% endif %}>Thrusts</a>
-      <a href="/engage"{% if page.url == '/engage' %} class="active"{% endif %}>Engage</a>
-      <a href="/news"{% if page.url == '/news' %} class="active"{% endif %}>News</a>
+
+    <div class="navlinks" id="navlinks">
+      <div class="navitem has-sub">
+        <a class="navlink{% if page.url contains '/about' %} active{% endif %}" href="/about">About</a>
+        <button class="sub-toggle" aria-expanded="false" aria-label="Show About submenu">
+          <svg width="10" height="10" viewBox="0 0 10 10"><path d="M1.5 3.5L5 7l3.5-3.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <div class="submenu">
+          <a href="/about/team">Team</a>
+        </div>
+      </div>
+
+      <a class="navlink{% if page.url == '/thrusts' %} active{% endif %}" href="/thrusts">Thrusts</a>
+
+      <div class="navitem has-sub">
+        <a class="navlink{% if page.url contains '/engage' %} active{% endif %}" href="/engage">Engage</a>
+        <button class="sub-toggle" aria-expanded="false" aria-label="Show Engage submenu">
+          <svg width="10" height="10" viewBox="0 0 10 10"><path d="M1.5 3.5L5 7l3.5-3.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <div class="submenu">
+          <a href="/engage/spack">Spack</a>
+          <a href="/engage/e4s">E4S</a>
+          <a href="/engage/hpsf">HPSF</a>
+        </div>
+      </div>
+
+      <a class="navlink{% if page.url == '/news' %} active{% endif %}" href="/news">News</a>
     </div>
+
+    <button class="nav-toggle" id="navToggle" aria-expanded="false" aria-controls="navlinks" aria-label="Toggle menu">
+      <span></span><span></span><span></span>
+    </button>
+
     <a class="nav-cta" href="/connect">Get involved</a>
   </div>
 </nav>
+
+<script>
+(function(){
+  var toggle = document.getElementById('navToggle');
+  var navlinks = document.getElementById('navlinks');
+
+  toggle.addEventListener('click', function(){
+    var open = navlinks.classList.toggle('open');
+    toggle.setAttribute('aria-expanded', open);
+  });
+
+  document.querySelectorAll('.sub-toggle').forEach(function(btn){
+    btn.addEventListener('click', function(e){
+      e.preventDefault();
+      var item = btn.closest('.navitem');
+      var isOpen = item.classList.contains('open');
+      document.querySelectorAll('.navitem.open').forEach(function(other){
+        if (other !== item) { other.classList.remove('open'); other.querySelector('.sub-toggle').setAttribute('aria-expanded', 'false'); }
+      });
+      item.classList.toggle('open', !isOpen);
+      btn.setAttribute('aria-expanded', !isOpen);
+    });
+  });
+
+  document.addEventListener('click', function(e){
+    if (!e.target.closest('.navitem')) {
+      document.querySelectorAll('.navitem.open').forEach(function(item){
+        item.classList.remove('open');
+        item.querySelector('.sub-toggle').setAttribute('aria-expanded', 'false');
+      });
+    }
+    if (!e.target.closest('#navlinks') && !e.target.closest('#navToggle')) {
+      navlinks.classList.remove('open');
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+  });
+})();
+</script>

--- a/about.md
+++ b/about.md
@@ -30,6 +30,35 @@ As part of ECP efforts, we facilitated the work of about 250 scientists from DOE
 
 PESO intends to participate in the extension and expansion of software-ecosystem sustainment, continuing the success that ECP started.
 
+## The problem space
+
+Every team building on scientific software hits the same wall eventually. PESO exists to move that wall.
+
+<div class="compare" style="margin-top:24px;">
+  <div class="compare-col friction">
+    <h3>Without a shared ecosystem</h3>
+    <ul>
+      <li>Installing 3rd-party libs breaks on dependency mismatches</li>
+      <li>Version updates introduce breaking changes downstream</li>
+      <li>New tools disrupt existing team workflows</li>
+      <li>Portability across CPU/GPU is manually managed</li>
+      <li>Build times balloon as projects grow</li>
+      <li>Algorithms fall out of date, hurting performance and security</li>
+    </ul>
+  </div>
+  <div class="compare-col help">
+    <h3>With PESO</h3>
+    <ul>
+      <li>Curated, tested library portfolio via Spack + E4S</li>
+      <li>Coordinated release and compatibility testing</li>
+      <li>User- and developer-experience research baked in</li>
+      <li>Community engagement as a first-order priority</li>
+      <li>Direct line to CASS community expertise</li>
+      <li>Shared investment across DOE, vendors, and academia</li>
+    </ul>
+  </div>
+</div>
+
 ## How we work
 
 Through collaborations, PESO provides:

--- a/assets/css/signal.css
+++ b/assets/css/signal.css
@@ -32,13 +32,43 @@ img{max-width:100%;}
 
 /* ---------- NAV (shared, always navy) ---------- */
 nav.site-nav{position:sticky; top:0; z-index:30; background:rgba(14,35,64,0.94); backdrop-filter:blur(8px);}
-nav.site-nav .wrap{display:flex; align-items:center; justify-content:space-between; height:72px;}
+nav.site-nav .wrap{display:flex; align-items:center; justify-content:space-between; height:72px; gap:20px;}
 .brand{display:flex; align-items:center; gap:10px; text-decoration:none;}
 .brand img{height:24px; width:auto; filter:brightness(0) invert(1);}
 .brand span{font-family:'Space Grotesk',sans-serif; font-weight:700; font-size:19px; color:#fff; letter-spacing:-0.01em;}
-.navlinks{display:flex; gap:32px; font-size:14.5px; color:#B7C4DA;}
+
+.navlinks{display:flex; align-items:center; gap:32px; font-size:14.5px; color:#B7C4DA; flex:1;}
 .navlinks a{text-decoration:none; transition:color .15s;}
 .navlinks a:hover, .navlinks a.active{color:#fff;}
+
+.navitem{position:relative; display:flex; align-items:center; gap:4px;}
+.sub-toggle{
+  background:none; border:none; padding:4px; margin:0; color:#B7C4DA; cursor:pointer;
+  display:flex; align-items:center; transition:color .15s, transform .15s;
+}
+.sub-toggle:hover{color:#fff;}
+.navitem.open .sub-toggle, .navitem:hover .sub-toggle{color:#fff;}
+.navitem.open .sub-toggle svg{transform:rotate(180deg);}
+
+.submenu{
+  display:none; position:absolute; top:100%; left:-14px; margin-top:14px;
+  background:var(--navy2); border:1px solid rgba(255,255,255,0.1); border-radius:8px;
+  padding:8px; min-width:150px; flex-direction:column; gap:2px;
+  box-shadow:0 12px 28px rgba(0,0,0,0.28);
+}
+.navitem:hover .submenu, .navitem.open .submenu{display:flex;}
+.submenu a{padding:8px 12px; border-radius:5px; color:#DCE6F7; white-space:nowrap;}
+.submenu a:hover{background:rgba(255,255,255,0.08); color:#fff;}
+
+.nav-toggle{
+  display:none; flex-direction:column; justify-content:center; gap:4px;
+  width:32px; height:32px; background:none; border:none; cursor:pointer; padding:0;
+}
+.nav-toggle span{display:block; width:20px; height:2px; background:#fff; border-radius:1px; transition:transform .2s, opacity .2s;}
+.nav-toggle[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg);}
+.nav-toggle[aria-expanded="true"] span:nth-child(2){opacity:0;}
+.nav-toggle[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg);}
+
 .nav-cta{
   background:var(--signal); color:#fff; font-weight:600; font-size:14px;
   padding:10px 20px; border-radius:24px; text-decoration:none; transition:background .15s; white-space:nowrap;
@@ -96,24 +126,11 @@ h1.page-title{
 }
 header.page-hero p.lede{max-width:640px; color:#C7D3E6;}
 
-/* ---------- STACK DIAGRAM — real bars, scaled to fit content ---------- */
-.stack{margin-top:64px; position:relative;}
-.stack-row{display:grid; grid-template-columns:170px 1fr; align-items:center; height:60px;}
-.stack-label{font-size:13.5px; font-weight:600; color:#DCE6F7;}
-.stack-bar{
-  height:44px; border-radius:6px; display:flex; align-items:center; padding:0 18px;
-  font-size:13.5px; font-weight:600; color:#0E2340; max-width:100%;
-}
-.stack-row:nth-child(1) .stack-bar{width:96%; background:#C9D8F7;}
-.stack-row:nth-child(2) .stack-bar{width:80%; background:#9DB8EF;}
-.stack-row:nth-child(3) .stack-bar{width:56%; background:var(--amber); color:#3A2306;}
-.stack-row:nth-child(4) .stack-bar{width:38%; background:#5C7CC7; color:#fff;}
-
 /* ---------- STATS band ---------- */
-.stats-band{background:var(--tint); border-bottom:1px solid var(--line);}
-.stats-grid{display:grid; grid-template-columns:repeat(4,1fr); padding:48px 0;}
+.stats-band{background:var(--tint); border-bottom:1px solid var(--line); padding:56px 0;}
+.stats-grid{display:grid; grid-template-columns:repeat(3,1fr); gap:32px 24px; padding-top:32px;}
 .stat{padding:0 24px; border-left:1px solid var(--line);}
-.stat:first-child{border-left:none; padding-left:0;}
+.stat:nth-child(3n+1){border-left:none; padding-left:0;}
 .stat .num{font-family:'Space Grotesk',sans-serif; font-weight:700; font-size:36px; color:var(--signal);}
 .stat .cap{font-size:13.5px; color:var(--muted); margin-top:6px;}
 
@@ -216,15 +233,38 @@ footer.site-footer img{height:26px; filter:brightness(0) invert(1) opacity(0.7);
 @media (max-width:860px){
   .compare{grid-template-columns:1fr;}
   .thrust-grid{grid-template-columns:1fr 1fr;}
-  .stats-grid{grid-template-columns:1fr 1fr; row-gap:32px;}
-  .stat:nth-child(3){border-left:none;}
+  .stats-grid{grid-template-columns:1fr 1fr;}
+  .stat:nth-child(3n+1){border-left:1px solid var(--line); padding-left:24px;}
+  .stat:nth-child(2n+1){border-left:none; padding-left:0;}
   .connect-grid{grid-template-columns:1fr;}
-  .navlinks{display:none;}
-  .stack-row{grid-template-columns:110px 1fr;}
+
+  .nav-toggle{display:flex;}
+  .navlinks{
+    display:none; position:absolute; top:100%; left:0; right:0;
+    flex-direction:column; align-items:stretch; gap:0; flex:none;
+    background:var(--navy); border-top:1px solid rgba(255,255,255,0.1);
+    padding:8px 0; max-height:calc(100vh - 72px); overflow-y:auto;
+  }
+  .navlinks.open{display:flex;}
+  .navlinks > a{display:block; padding:14px 24px; border-bottom:1px solid rgba(255,255,255,0.06);}
+  .navitem{
+    display:flex; flex-wrap:wrap; align-items:center; gap:0;
+    padding:0 24px; border-bottom:1px solid rgba(255,255,255,0.06);
+  }
+  .navitem > .navlink{flex:1; padding:14px 0;}
+  .sub-toggle{padding:14px 4px;}
+  .submenu{
+    display:none; position:static; box-shadow:none; border:none; background:none;
+    margin:0 0 8px; padding:0 0 0 12px; width:100%; min-width:0;
+  }
+  .navitem:hover .submenu{display:none;}
+  .navitem.open .submenu{display:flex;}
+  .submenu a{padding:10px 12px; color:#B7C4DA;}
 }
 @media (max-width:560px){
   .thrust-grid{grid-template-columns:1fr;}
-  .stats-grid{grid-template-columns:1fr 1fr;}
+  .stats-grid{grid-template-columns:1fr;}
+  .stat{border-left:none; padding-left:0;}
   .wrap{padding:0 24px;}
   .cta-band .wrap{flex-direction:column; align-items:flex-start;}
 }

--- a/assets/css/signal.css
+++ b/assets/css/signal.css
@@ -157,13 +157,6 @@ a.thrust:hover{box-shadow:0 4px 18px rgba(14,35,64,0.08);}
 .thrust h3{font-size:16.5px; font-weight:700; color:var(--ink); margin-bottom:8px;}
 .thrust p{font-size:14px; color:var(--muted); line-height:1.55;}
 
-/* ---------- THRUST PREVIEW (compact — homepage teaser) ---------- */
-.thrust-mini-grid{display:grid; grid-template-columns:repeat(3,1fr); gap:1px; background:var(--line); border:1px solid var(--line); border-radius:14px; overflow:hidden;}
-.thrust-mini{background:#fff; padding:20px 22px; display:block; text-decoration:none; color:inherit; transition:background .15s;}
-.thrust-mini:hover{background:var(--tint);}
-.thrust-mini .code{font-family:'Space Grotesk',sans-serif; font-size:12px; font-weight:700; color:var(--signal-dark); letter-spacing:0.04em; display:block; margin-bottom:6px;}
-.thrust-mini .name{font-size:14.5px; font-weight:600; color:var(--ink);}
-
 /* ---------- NEWS ---------- */
 .log{border-top:1px solid var(--line);}
 .log-row{display:grid; grid-template-columns:150px 1fr; gap:20px; padding:18px 0; border-bottom:1px solid var(--line); align-items:baseline;}
@@ -223,7 +216,6 @@ footer.site-footer img{height:26px; filter:brightness(0) invert(1) opacity(0.7);
 @media (max-width:860px){
   .compare{grid-template-columns:1fr;}
   .thrust-grid{grid-template-columns:1fr 1fr;}
-  .thrust-mini-grid{grid-template-columns:1fr;}
   .stats-grid{grid-template-columns:1fr 1fr; row-gap:32px;}
   .stat:nth-child(3){border-left:none;}
   .connect-grid{grid-template-columns:1fr;}

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ permalink: /
         <div class="section-tag">The problem space</div>
         <h2>Familiar failure modes</h2>
       </div>
-      <p class="section-desc">Every team building on scientific software hits the same wall eventually. <a href="/about" style="color:var(--signal-dark); text-decoration:underline;">Read the full story →</a></p>
+      <p class="section-desc">Every team building on scientific software hits the same wall eventually. <a href="/about#the-problem-space" style="color:var(--signal-dark); text-decoration:underline;">Read the full story →</a></p>
     </div>
     <div class="compare">
       <div class="compare-col friction">
@@ -38,43 +38,6 @@ permalink: /
           <li>Shared investment across DOE, vendors, and academia</li>
         </ul>
       </div>
-    </div>
-  </div>
-</section>
-
-<section class="bordered" id="thrusts">
-  <div class="wrap">
-    <div class="section-head">
-      <div>
-        <div class="section-tag">Program structure</div>
-        <h2>Six thrusts, one ecosystem</h2>
-      </div>
-      <p class="section-desc">Parallel work areas, each shipping into the same shared stack.</p>
-    </div>
-    <div class="thrust-mini-grid">
-      {% for t in site.data.thrusts %}
-      <a class="thrust-mini" href="{{ t.link | default: '/thrusts' }}">
-        <span class="code">{{ t.code }}</span>
-        <span class="name">{{ t.title }}</span>
-      </a>
-      {% endfor %}
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="wrap">
-    <div class="section-head">
-      <div>
-        <div class="section-tag">Updates</div>
-        <h2>Latest news</h2>
-      </div>
-      <p class="section-desc"><a href="/news" style="color:var(--signal-dark); text-decoration:underline;">See all news →</a></p>
-    </div>
-    <div class="log">
-      {% for news in site.data.news limit: 3 %}
-      <div class="log-row"><span class="log-date mono">{{ news.date }}</span><a href="{{ news.link }}">{{ news.title }}</a></div>
-      {% endfor %}
     </div>
   </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -3,44 +3,52 @@ layout: default
 permalink: /
 ---
 
-<div class="stats-band">
-  <div class="wrap stats-grid">
-    <div class="stat"><div class="num grotesk">6</div><div class="cap">Parallel thrusts</div></div>
-    <div class="stat"><div class="num grotesk">140+</div><div class="cap">Libraries &amp; tools via E4S</div></div>
-    <div class="stat"><div class="num grotesk">2</div><div class="cap">Delivery platforms — E4S &amp; Spack</div></div>
-    <div class="stat"><div class="num grotesk">4</div><div class="cap">Stakeholder groups aligned</div></div>
-  </div>
-</div>
-
 <section class="bordered">
   <div class="wrap">
     <div class="section-head">
       <div>
-        <div class="section-tag">The problem space</div>
-        <h2>Familiar failure modes</h2>
+        <div class="section-tag">How PESO operates</div>
+        <h2>Partnerships, services, and products</h2>
       </div>
-      <p class="section-desc">Every team building on scientific software hits the same wall eventually. <a href="/about#the-problem-space" style="color:var(--signal-dark); text-decoration:underline;">Read the full story →</a></p>
+      <p class="section-desc">Every team building on scientific software hits the same wall eventually. <a href="/about#the-problem-space" style="color:var(--signal-dark); text-decoration:underline;">See the problem PESO solves →</a></p>
     </div>
-    <div class="compare">
-      <div class="compare-col friction">
-        <h3>Without a shared ecosystem</h3>
-        <ul>
-          <li>Installing 3rd-party libs breaks on dependency mismatches</li>
-          <li>Version updates introduce breaking changes downstream</li>
-          <li>Portability across CPU/GPU is manually managed</li>
-        </ul>
+    <div class="thrust-grid">
+      <div class="thrust">
+        <span class="thrust-code">PARTNERSHIPS</span>
+        <h3>Stakeholder &amp; consortium engagement</h3>
+        <p>Stakeholder engagement across the CASS consortium, computing facilities, commercial HPC companies, US agencies, and industrial users — plus community development through the Better Scientific Software (BSSw) Fellowship Program and workforce initiatives.</p>
       </div>
-      <div class="compare-col help">
-        <h3>With PESO</h3>
-        <ul>
-          <li>Curated, tested library portfolio via Spack + E4S</li>
-          <li>Coordinated release and compatibility testing</li>
-          <li>Shared investment across DOE, vendors, and academia</li>
-        </ul>
+      <div class="thrust">
+        <span class="thrust-code">SERVICES</span>
+        <h3>Integration, SQA &amp; security</h3>
+        <p>Integration partnerships — Spack integration, CI testing, portfolio support and management, collaboration with software stewardship organizations — plus software quality assurance and security: supply chain, product quality, testing, and documentation.</p>
+      </div>
+      <div class="thrust">
+        <span class="thrust-code">PRODUCTS</span>
+        <h3>E4S, Spack &amp; platforms</h3>
+        <p>E4S and Spack integration, features, documentation, and training; the Frank test &amp; development platform plus cloud resources; and BSSw.io articles on scientific software productivity and sustainability.</p>
       </div>
     </div>
   </div>
 </section>
+
+<div class="stats-band">
+  <div class="wrap section-head" style="margin-bottom:8px;">
+    <div>
+      <div class="section-tag" style="background:#fff;">Ecosystem benefits</div>
+      <h2>Powers of ten</h2>
+    </div>
+    <p class="section-desc">Technical and community benefits, at every scale. <a href="/engage#powers-of-ten" style="color:var(--signal-dark); text-decoration:underline;">Read more on Engage →</a></p>
+  </div>
+  <div class="wrap stats-grid">
+    <div class="stat"><div class="num grotesk">100,000+</div><div class="cap">Lines of code replaced with high-quality libraries and tools</div></div>
+    <div class="stat"><div class="num grotesk">10,000+</div><div class="cap">Community members via ecosystem collaborations</div></div>
+    <div class="stat"><div class="num grotesk">1,000+</div><div class="cap">Code teams share ecosystem costs and benefits</div></div>
+    <div class="stat"><div class="num grotesk">100+</div><div class="cap">Speedup using advanced devices like GPUs</div></div>
+    <div class="stat"><div class="num grotesk">10+</div><div class="cap">Reduction in build times via Spack build caches</div></div>
+    <div class="stat"><div class="num grotesk">1</div><div class="cap">Source code base for all computing systems</div></div>
+  </div>
+</div>
 
 <div class="cta-band">
   <div class="wrap">


### PR DESCRIPTION
Continues the site redesign from PR #2, all on the homepage-problem-space branch:

- Shortened the homepage (hero, brief problem/solution, one CTA), moved the full problem/solution comparison to `/about`.
- Refreshed homepage copy and stats to match the project's official overview one-pager: real mission statement, PI credit, "Partnerships, services, and products" framing, and the full six-item "Powers of Ten" stats.
- Removed the now out-of-place stack diagram from the hero.
- Added submenus to the About and Engage nav items (hover on desktop, accordion on mobile via a new hamburger menu).

See individual commit messages for full detail. Verified with a full Jekyll build and manual browser passes throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)