### PR TITLE
Split About into Mission/Vision/Background, Problem Space, and Project Details

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,8 @@
 <div class="wrap">
     <div class="footer-links">
         <a href="/about">About</a>
+        <a href="/about/problem-space">Problem Space</a>
+        <a href="/about/details">Project Details</a>
         <a href="/about/team">Team</a>
         <a href="/thrusts">Thrusts</a>
         <a href="/engage">Engage</a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -12,6 +12,8 @@
           <svg width="10" height="10" viewBox="0 0 10 10"><path d="M1.5 3.5L5 7l3.5-3.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
         <div class="submenu">
+          <a href="/about/problem-space">Problem Space</a>
+          <a href="/about/details">Project Details</a>
           <a href="/about/team">Team</a>
         </div>
       </div>

--- a/about.md
+++ b/about.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: About PESO
-description: Mission, vision, background, and how PESO works with the scientific software community.
+description: Mission, vision, and background of the PESO Project.
 section_tag: About PESO
 permalink: /about
 ---
@@ -30,74 +30,4 @@ As part of ECP efforts, we facilitated the work of about 250 scientists from DOE
 
 PESO intends to participate in the extension and expansion of software-ecosystem sustainment, continuing the success that ECP started.
 
-## The problem space
-
-Every team building on scientific software hits the same wall eventually. PESO exists to move that wall.
-
-<div class="compare" style="margin-top:24px;">
-  <div class="compare-col friction">
-    <h3>Without a shared ecosystem</h3>
-    <ul>
-      <li>Installing 3rd-party libs breaks on dependency mismatches</li>
-      <li>Version updates introduce breaking changes downstream</li>
-      <li>New tools disrupt existing team workflows</li>
-      <li>Portability across CPU/GPU is manually managed</li>
-      <li>Build times balloon as projects grow</li>
-      <li>Algorithms fall out of date, hurting performance and security</li>
-    </ul>
-  </div>
-  <div class="compare-col help">
-    <h3>With PESO</h3>
-    <ul>
-      <li>Curated, tested library portfolio via Spack + E4S</li>
-      <li>Coordinated release and compatibility testing</li>
-      <li>User- and developer-experience research baked in</li>
-      <li>Community engagement as a first-order priority</li>
-      <li>Direct line to CASS community expertise</li>
-      <li>Shared investment across DOE, vendors, and academia</li>
-    </ul>
-  </div>
-</div>
-
-## How we work
-
-Through collaborations, PESO provides:
-
-- **Software stacks and infrastructure** — testing, hardening, integration, distribution, and intermediate user support for a product, whether as its final destination, an early-access staging environment for pre-release versions, or both:
-  - **Spack** — assistance creating and expanding [Spack](https://spack.io) capabilities for product build, testing, integration, and distribution.
-  - **E4S** — support for product integration and distribution in the Extreme-scale Scientific Software Stack ([E4S](https://e4s.io)), depending on a team's distribution strategy.
-  - **CI** — continuous integration testing on a variety of commodity and emerging target vendor hardware/software stacks.
-  - **Software quality improvement** — assistance improving product compatibility with E4S community policies.
-- **Stakeholder engagement** — opportunities for software teams and communities to engage with DOE, vendors, application communities, and cross-lab management.
-- **An annual all-teams workshop** — bringing together product teams, stakeholders, and other key parties for planning and coordination.
-
-PESO welcomes engagement at several levels:
-
-- **Individual product teams** whose products would benefit DOE application users and facilities — ideally also participating in a compatible product community, typically a DOE-sponsored software stewardship organization (SSO).
-- **Software product communities ("spokes")** — new and established communities that define their own quality-driving policies, ideally compatible with E4S community policies where products distribute through E4S.
-- **Communities of practice** organized around cross-cutting concerns — research software engineering training (e.g., [IDEAS](https://ideas-productivity.org)), community outreach (e.g., [CSCCE](https://cscce.org) strategies), software foundations (e.g., [NumFOCUS](https://numfocus.org), [Linux Foundation](https://www.linuxfoundation.org)), and workforce development (e.g., [US RSE](https://us-rse.org), [BSSw Fellows](https://bssw.io/fellowship), [Sustainable Research Pathways](https://bssw.io/events/sustainable-research-pathways-srp)).
-
-And with stakeholders and partners directly:
-
-- **Application teams**, coordinating delivery via E4S, containers, cloud, and facilities environments.
-- **DOE computing facilities**, providing and supporting a full stack of DOE-sponsored libraries and tools via E4S, in collaboration with commercial E4S partners.
-- **Computer system vendors**, ensuring DOE-sponsored libraries and tools are available as part of or complementary to vendor software.
-- **Commercial software providers**, co-developing and supporting DOE-sponsored software for industry, US agencies, and international partners.
-- **US agencies**, making DOE-sponsored software available to their users while assuring compatibility with their own software environments.
-
-## Principles
-
-- **Transparency** — open governance policies and open access to Consortium artifacts.
-- **Diversity** — cultivation of diverse participation and representation.
-- **Sustainability** — long-term viability and growth of software, practices, and workforce.
-- **Innovation** — responsiveness to stakeholder needs and technological evolution.
-- **Cooperation** — working together to support the overall Consortium mission.
-- **Integrity** — acting as a fair, trusted, and respected asset to the community.
-
-## Key activities
-
-- **Partnerships** — leading efforts to foster a diverse and inclusive workforce with sustainable career paths; shepherding the Better Scientific Software Fellows Program and contributing to the leadership of the [BSSw.io](https://bssw.io) web portal.
-- **Services** — software product management, integration, and delivery, plus software quality assurance and security.
-- **Products** — delivery and support via Spack and E4S, including porting and testing platforms shared across product teams to ensure code stability and portability, and facilitating delivery of other products such as AI/ML libraries as needed by the HPC community.
-
-Want to be part of this? See how to [connect with PESO](/connect) or meet the [team](/about/team).
+Want the full picture? See [the problem PESO solves](/about/problem-space), [how PESO operates](/about/details), or meet the [team](/about/team) — or go ahead and [connect with PESO](/connect).

--- a/about/details.md
+++ b/about/details.md
@@ -1,0 +1,50 @@
+---
+title: PESO Project Details
+description: How PESO operates, its guiding principles, and its key activities.
+section_tag: About PESO
+layout: page
+permalink: /about/details
+---
+
+## How we work
+
+Through collaborations, PESO provides:
+
+- **Software stacks and infrastructure** — testing, hardening, integration, distribution, and intermediate user support for a product, whether as its final destination, an early-access staging environment for pre-release versions, or both:
+  - **Spack** — assistance creating and expanding [Spack](https://spack.io) capabilities for product build, testing, integration, and distribution.
+  - **E4S** — support for product integration and distribution in the Extreme-scale Scientific Software Stack ([E4S](https://e4s.io)), depending on a team's distribution strategy.
+  - **CI** — continuous integration testing on a variety of commodity and emerging target vendor hardware/software stacks.
+  - **Software quality improvement** — assistance improving product compatibility with E4S community policies.
+- **Stakeholder engagement** — opportunities for software teams and communities to engage with DOE, vendors, application communities, and cross-lab management.
+- **An annual all-teams workshop** — bringing together product teams, stakeholders, and other key parties for planning and coordination.
+
+PESO welcomes engagement at several levels:
+
+- **Individual product teams** whose products would benefit DOE application users and facilities — ideally also participating in a compatible product community, typically a DOE-sponsored software stewardship organization (SSO).
+- **Software product communities ("spokes")** — new and established communities that define their own quality-driving policies, ideally compatible with E4S community policies where products distribute through E4S.
+- **Communities of practice** organized around cross-cutting concerns — research software engineering training (e.g., [IDEAS](https://ideas-productivity.org)), community outreach (e.g., [CSCCE](https://cscce.org) strategies), software foundations (e.g., [NumFOCUS](https://numfocus.org), [Linux Foundation](https://www.linuxfoundation.org)), and workforce development (e.g., [US RSE](https://us-rse.org), [BSSw Fellows](https://bssw.io/fellowship), [Sustainable Research Pathways](https://bssw.io/events/sustainable-research-pathways-srp)).
+
+And with stakeholders and partners directly:
+
+- **Application teams**, coordinating delivery via E4S, containers, cloud, and facilities environments.
+- **DOE computing facilities**, providing and supporting a full stack of DOE-sponsored libraries and tools via E4S, in collaboration with commercial E4S partners.
+- **Computer system vendors**, ensuring DOE-sponsored libraries and tools are available as part of or complementary to vendor software.
+- **Commercial software providers**, co-developing and supporting DOE-sponsored software for industry, US agencies, and international partners.
+- **US agencies**, making DOE-sponsored software available to their users while assuring compatibility with their own software environments.
+
+## Principles
+
+- **Transparency** — open governance policies and open access to Consortium artifacts.
+- **Diversity** — cultivation of diverse participation and representation.
+- **Sustainability** — long-term viability and growth of software, practices, and workforce.
+- **Innovation** — responsiveness to stakeholder needs and technological evolution.
+- **Cooperation** — working together to support the overall Consortium mission.
+- **Integrity** — acting as a fair, trusted, and respected asset to the community.
+
+## Key activities
+
+- **Partnerships** — leading efforts to foster a diverse and inclusive workforce with sustainable career paths; shepherding the Better Scientific Software Fellows Program and contributing to the leadership of the [BSSw.io](https://bssw.io) web portal.
+- **Services** — software product management, integration, and delivery, plus software quality assurance and security.
+- **Products** — delivery and support via Spack and E4S, including porting and testing platforms shared across product teams to ensure code stability and portability, and facilitating delivery of other products such as AI/ML libraries as needed by the HPC community.
+
+Want to be part of this? See how to [connect with PESO](/connect) or meet the [team](/about/team).

--- a/about/problem-space.md
+++ b/about/problem-space.md
@@ -1,0 +1,36 @@
+---
+title: The Problem Space
+description: The failure modes PESO exists to fix, and how the ecosystem approach resolves them.
+section_tag: About PESO
+layout: page
+permalink: /about/problem-space
+---
+
+Every team building on scientific software hits the same wall eventually. PESO exists to move that wall.
+
+<div class="compare" style="margin-top:24px;">
+  <div class="compare-col friction">
+    <h3>Without a shared ecosystem</h3>
+    <ul>
+      <li>Installing 3rd-party libs breaks on dependency mismatches</li>
+      <li>Version updates introduce breaking changes downstream</li>
+      <li>New tools disrupt existing team workflows</li>
+      <li>Portability across CPU/GPU is manually managed</li>
+      <li>Build times balloon as projects grow</li>
+      <li>Algorithms fall out of date, hurting performance and security</li>
+    </ul>
+  </div>
+  <div class="compare-col help">
+    <h3>With PESO</h3>
+    <ul>
+      <li>Curated, tested library portfolio via Spack + E4S</li>
+      <li>Coordinated release and compatibility testing</li>
+      <li>User- and developer-experience research baked in</li>
+      <li>Community engagement as a first-order priority</li>
+      <li>Direct line to CASS community expertise</li>
+      <li>Shared investment across DOE, vendors, and academia</li>
+    </ul>
+  </div>
+</div>
+
+Want the rest of the story? See [PESO Project Details](/about/details) for how PESO operates, its guiding principles, and key activities.

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ permalink: /
         <div class="section-tag">How PESO operates</div>
         <h2>Partnerships, services, and products</h2>
       </div>
-      <p class="section-desc">Every team building on scientific software hits the same wall eventually. <a href="/about#the-problem-space" style="color:var(--signal-dark); text-decoration:underline;">See the problem PESO solves →</a></p>
+      <p class="section-desc">Every team building on scientific software hits the same wall eventually. <a href="/about/problem-space" style="color:var(--signal-dark); text-decoration:underline;">See the problem PESO solves →</a></p>
     </div>
     <div class="thrust-grid">
       <div class="thrust">


### PR DESCRIPTION
- /about now covers only Mission, Vision, and Background.
- New /about/problem-space carries "The Problem Space" comparison.
- New /about/details ("PESO Project Details") combines How We Work, Principles, and Key Activities.
- Nav's About submenu, footer, and the homepage link all updated accordingly.

Verified with a full Jekyll build and manual browser pass across all four About pages plus the homepage link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)