### PR TITLE
Split News into Events/Documents; fix dropdown hover gap; add Genesis Mission page

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,60 +1,74 @@
 - title: DOE Computer Science PI Meeting 2026
   link: /cs-pi-2026
   date: July 21-22, 2026
+  category: event
 
 - title: 2026 CASS Community BOF Days
   link: /files/2026CASSCommunityBOFDays.pdf
   date: February 10-12, 2026
+  category: event
 
 - title: PESO 2025 Annual Report
   link: /files/2025PESOProjectReport.pdf
   date: January 13, 2026
+  category: document
 
-- title: New E4S Website 
+- title: New E4S Website
   link: https://e4s.io/new-features
   date: December 10, 2025
+  category: document
 
 - title: PESO at SC25
   link: https://cass.community/news/2025-11-16-sc25.html
   date: November 16-20, 2025
+  category: event
 
 - title: E4S Version 25.11 Release
   link: https://e4s.io/news/NEWS_RELEASE_E4S_25.11.pdf
   date: November 17, 2025
+  category: document
 
 - title: E4S Version 25.06 Release
   link: https://e4s.io/news/NEWS_RELEASE_E4S_25.06.pdf
   date: June 6, 2025
+  category: document
 
 - title: PESO 2024 Annual Report
   link: /files/2024PESOProjectReport.pdf
   date: March 21, 2025
+  category: document
 
 - title: PESO/CASS Talks from SIAM CSE25 in Fort Worth, TX
   link: /cse25
   date: March 3 - 7, 2025
+  category: event
 
 - title: E4S Version 24.11 Release
   link: https://e4s.io
   date: November 15, 2024
+  category: document
 
 - title: Google's NotebookLM Explains PESO
   link: /notebooklm
   date: November 18, 2024
+  category: document
 
 - title: PESO's View on a Cohesive AI/ModSim Software Ecosystem
   link: https://arxiv.org/abs/2411.09507
   date: November 19, 2024
+  category: document
 
 - title: PESO at SC24 in Atlanta, GA
   link: /sc24
   date: November 18 - 22, 2024
+  category: event
 
 - title: BSSw Fellows Announced at USRSE24
   link: https://us-rse.org/usrse24/
   date: October 15, 2024
+  category: event
 
 - title: PESO at the Energy Earthshots Meeting
   link: https://www.energy.gov/energy-earthshots-initiative
   date: September 4 - 5, 2024
-  
+  category: event

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,8 +5,11 @@
         <a href="/about/details">Project Details</a>
         <a href="/about/team">Team</a>
         <a href="/thrusts">Thrusts</a>
+        <a href="/genesis-mission">Genesis Mission</a>
         <a href="/engage">Engage</a>
         <a href="/news">News</a>
+        <a href="/news/events">Events</a>
+        <a href="/news/documents">Documents</a>
         <a href="/connect">Connect</a>
     </div>
     <span class="mono">© {{ site.time | date: '%Y' }} The PESO Project</span>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -12,9 +12,11 @@
           <svg width="10" height="10" viewBox="0 0 10 10"><path d="M1.5 3.5L5 7l3.5-3.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
         <div class="submenu">
-          <a href="/about/problem-space">Problem Space</a>
-          <a href="/about/details">Project Details</a>
-          <a href="/about/team">Team</a>
+          <div class="submenu-panel">
+            <a href="/about/problem-space">Problem Space</a>
+            <a href="/about/details">Project Details</a>
+            <a href="/about/team">Team</a>
+          </div>
         </div>
       </div>
 
@@ -26,20 +28,33 @@
           <svg width="10" height="10" viewBox="0 0 10 10"><path d="M1.5 3.5L5 7l3.5-3.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
         <div class="submenu">
-          <a href="/engage/spack">Spack</a>
-          <a href="/engage/e4s">E4S</a>
-          <a href="/engage/hpsf">HPSF</a>
+          <div class="submenu-panel">
+            <a href="/engage/spack">Spack</a>
+            <a href="/engage/e4s">E4S</a>
+            <a href="/engage/hpsf">HPSF</a>
+          </div>
         </div>
       </div>
 
-      <a class="navlink{% if page.url == '/news' %} active{% endif %}" href="/news">News</a>
+      <div class="navitem has-sub">
+        <a class="navlink{% if page.url contains '/news' %} active{% endif %}" href="/news">News</a>
+        <button class="sub-toggle" aria-expanded="false" aria-label="Show News submenu">
+          <svg width="10" height="10" viewBox="0 0 10 10"><path d="M1.5 3.5L5 7l3.5-3.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <div class="submenu">
+          <div class="submenu-panel">
+            <a href="/news/events">Events</a>
+            <a href="/news/documents">Documents</a>
+          </div>
+        </div>
+      </div>
     </div>
 
     <button class="nav-toggle" id="navToggle" aria-expanded="false" aria-controls="navlinks" aria-label="Toggle menu">
       <span></span><span></span><span></span>
     </button>
 
-    <a class="nav-cta" href="/connect">Get involved</a>
+    <a class="nav-cta" href="/genesis-mission">PESO for Genesis Mission</a>
   </div>
 </nav>
 

--- a/assets/css/signal.css
+++ b/assets/css/signal.css
@@ -51,9 +51,12 @@ nav.site-nav .wrap{display:flex; align-items:center; justify-content:space-betwe
 .navitem.open .sub-toggle svg{transform:rotate(180deg);}
 
 .submenu{
-  display:none; position:absolute; top:100%; left:-14px; margin-top:14px;
+  display:none; position:absolute; top:100%; left:-14px; margin-top:0; padding-top:14px;
+  flex-direction:column;
+}
+.submenu-panel{
   background:var(--navy2); border:1px solid rgba(255,255,255,0.1); border-radius:8px;
-  padding:8px; min-width:150px; flex-direction:column; gap:2px;
+  padding:8px; min-width:150px; display:flex; flex-direction:column; gap:2px;
   box-shadow:0 12px 28px rgba(0,0,0,0.28);
 }
 .navitem:hover .submenu, .navitem.open .submenu{display:flex;}
@@ -173,6 +176,8 @@ a.thrust:hover{box-shadow:0 4px 18px rgba(14,35,64,0.08);}
 }
 .thrust h3{font-size:16.5px; font-weight:700; color:var(--ink); margin-bottom:8px;}
 .thrust p{font-size:14px; color:var(--muted); line-height:1.55;}
+.thrust .outcome-label{font-size:11px; font-weight:700; letter-spacing:0.06em; text-transform:uppercase; color:var(--muted); margin-top:16px; padding-top:14px; border-top:1px solid var(--line);}
+.thrust .outcome-text{font-size:13.5px; font-weight:700; color:var(--ink); margin-top:4px;}
 
 /* ---------- NEWS ---------- */
 .log{border-top:1px solid var(--line);}
@@ -205,29 +210,33 @@ footer.site-footer .mono{font-size:13px; color:#8296B4;}
 footer.site-footer img{height:26px; filter:brightness(0) invert(1) opacity(0.7);}
 
 /* ---------- GENERIC MARKDOWN PAGE CONTENT ---------- */
+/* :where(.page-content) carries zero specificity, so these generic
+   markdown-prose defaults never fight with embedded UI components
+   (.thrust, .connect-card, .log-row, etc.) regardless of source order —
+   any component-specific rule always wins over these base styles. */
 .page-content{padding:64px 0 88px;}
-.page-content h1{font-family:'Space Grotesk',sans-serif; font-weight:700; color:var(--ink); font-size:clamp(22px,2.6vw,28px); margin:44px 0 18px;}
-.page-content h1:first-child{margin-top:0;}
-.page-content h2{margin:44px 0 16px; font-size:clamp(20px,2.2vw,25px);}
-.page-content h2:first-child{margin-top:0;}
-.page-content h3{font-family:'Space Grotesk',sans-serif; font-weight:700; color:var(--ink); font-size:17px; margin:30px 0 10px;}
-.page-content h4{font-size:15px; font-weight:700; color:var(--ink); margin:22px 0 8px;}
-.page-content p{color:var(--ink); font-size:15.5px; margin-bottom:16px; max-width:760px;}
-.page-content ul, .page-content ol{color:var(--ink); font-size:15.5px; margin:0 0 16px 1.3em;}
-.page-content li{margin-bottom:6px;}
-.page-content a{color:var(--signal-dark); text-decoration:underline; text-decoration-color:rgba(47,95,224,0.3); text-underline-offset:2px;}
-.page-content a:hover{text-decoration-color:var(--signal-dark);}
-.page-content strong{color:var(--ink);}
-.page-content hr{border:none; border-top:1px solid var(--line); margin:36px 0;}
-.page-content blockquote{border-left:3px solid var(--signal); padding-left:18px; color:var(--muted); margin:20px 0;}
-.page-content code{font-family:ui-monospace,'SF Mono',Menlo,monospace; font-size:0.88em; color:var(--signal-dark); background:var(--tint); border-radius:4px; padding:2px 6px;}
-.page-content pre{background:var(--tint); border-radius:10px; padding:18px 20px; overflow-x:auto; margin-bottom:20px;}
-.page-content pre code{background:none; padding:0;}
-.page-content table{width:100%; border-collapse:collapse; margin:8px 0 28px; border:1px solid var(--line); border-radius:10px; overflow:hidden;}
-.page-content th{font-size:12px; letter-spacing:0.04em; text-transform:uppercase; color:var(--signal-dark); text-align:left; padding:12px 16px; background:var(--tint); border-bottom:1px solid var(--line);}
-.page-content td{padding:12px 16px; border-bottom:1px solid var(--line); font-size:14.5px; color:var(--ink); vertical-align:top;}
-.page-content tr:last-child td{border-bottom:none;}
-.page-content tbody tr:hover{background:var(--tint);}
+:where(.page-content) h1{font-family:'Space Grotesk',sans-serif; font-weight:700; color:var(--ink); font-size:clamp(22px,2.6vw,28px); margin:44px 0 18px;}
+:where(.page-content) h1:first-child{margin-top:0;}
+:where(.page-content) h2{margin:44px 0 16px; font-size:clamp(20px,2.2vw,25px);}
+:where(.page-content) h2:first-child{margin-top:0;}
+:where(.page-content) h3{font-family:'Space Grotesk',sans-serif; font-weight:700; color:var(--ink); font-size:17px; margin:30px 0 10px;}
+:where(.page-content) h4{font-size:15px; font-weight:700; color:var(--ink); margin:22px 0 8px;}
+:where(.page-content) p{color:var(--ink); font-size:15.5px; margin-bottom:16px; max-width:760px;}
+:where(.page-content) ul, :where(.page-content) ol{color:var(--ink); font-size:15.5px; margin:0 0 16px 1.3em;}
+:where(.page-content) li{margin-bottom:6px;}
+:where(.page-content) a{color:var(--signal-dark); text-decoration:underline; text-decoration-color:rgba(47,95,224,0.3); text-underline-offset:2px;}
+:where(.page-content) a:hover{text-decoration-color:var(--signal-dark);}
+:where(.page-content) strong{color:var(--ink);}
+:where(.page-content) hr{border:none; border-top:1px solid var(--line); margin:36px 0;}
+:where(.page-content) blockquote{border-left:3px solid var(--signal); padding-left:18px; color:var(--muted); margin:20px 0;}
+:where(.page-content) code{font-family:ui-monospace,'SF Mono',Menlo,monospace; font-size:0.88em; color:var(--signal-dark); background:var(--tint); border-radius:4px; padding:2px 6px;}
+:where(.page-content) pre{background:var(--tint); border-radius:10px; padding:18px 20px; overflow-x:auto; margin-bottom:20px;}
+:where(.page-content) pre code{background:none; padding:0;}
+:where(.page-content) table{width:100%; border-collapse:collapse; margin:8px 0 28px; border:1px solid var(--line); border-radius:10px; overflow:hidden;}
+:where(.page-content) th{font-size:12px; letter-spacing:0.04em; text-transform:uppercase; color:var(--signal-dark); text-align:left; padding:12px 16px; background:var(--tint); border-bottom:1px solid var(--line);}
+:where(.page-content) td{padding:12px 16px; border-bottom:1px solid var(--line); font-size:14.5px; color:var(--ink); vertical-align:top;}
+:where(.page-content) tr:last-child td{border-bottom:none;}
+:where(.page-content) tbody tr:hover{background:var(--tint);}
 
 /* ---------- RESPONSIVE ---------- */
 @media (max-width:860px){
@@ -254,8 +263,10 @@ footer.site-footer img{height:26px; filter:brightness(0) invert(1) opacity(0.7);
   .navitem > .navlink{flex:1; padding:14px 0;}
   .sub-toggle{padding:14px 4px;}
   .submenu{
-    display:none; position:static; box-shadow:none; border:none; background:none;
-    margin:0 0 8px; padding:0 0 0 12px; width:100%; min-width:0;
+    display:none; position:static; margin:0 0 8px; padding-top:0; width:100%;
+  }
+  .submenu-panel{
+    background:none; border:none; box-shadow:none; padding:0 0 0 12px; min-width:0;
   }
   .navitem:hover .submenu{display:none;}
   .navitem.open .submenu{display:flex;}

--- a/genesis-mission.md
+++ b/genesis-mission.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: Shared software foundations for mission-scale science.
+description: Each collaboration starts with a real team workflow and complements — rather than replaces — the work of product teams, facilities, and domain scientists.
+section_tag: For DOE Genesis Mission Teams
+permalink: /genesis-mission
+---
+
+<div class="thrust-grid" style="margin-top:8px;">
+  <div class="thrust">
+    <span class="thrust-code">01</span>
+    <h3>Stand up a mission-ready software stack</h3>
+    <p>Turn a project's libraries, tools, and dependencies into a coherent, version-compatible environment using E4S and Spack — ready for repeatable science from day one.</p>
+    <div class="outcome-label">Outcome</div>
+    <div class="outcome-text">A documented, reproducible starting point</div>
+  </div>
+  <div class="thrust">
+    <span class="thrust-code">02</span>
+    <h3>De-risk deployment across facilities</h3>
+    <p>Work through portability issues across leadership systems, accelerators, clusters, cloud-adjacent platforms, and emerging architectures before they slow the science.</p>
+    <div class="outcome-label">Outcome</div>
+    <div class="outcome-text">Fewer platform surprises and faster onboarding</div>
+  </div>
+  <div class="thrust">
+    <span class="thrust-code">03</span>
+    <h3>Build an integration &amp; assurance lane</h3>
+    <p>Add ecosystem-level continuous integration, compatibility testing, software quality practices, and supply-chain security to catch failures at the seams between products.</p>
+    <div class="outcome-label">Outcome</div>
+    <div class="outcome-text">Trusted releases with visible evidence</div>
+  </div>
+  <div class="thrust">
+    <span class="thrust-code">04</span>
+    <h3>Connect AI, simulation &amp; data workflows</h3>
+    <p>Identify interoperability gaps where models, equation-based components, workflows, and data services meet — then coordinate the software teams needed to close them.</p>
+    <div class="outcome-label">Outcome</div>
+    <div class="outcome-text">A workflow that behaves like one system</div>
+  </div>
+  <div class="thrust">
+    <span class="thrust-code">05</span>
+    <h3>Improve the researcher experience</h3>
+    <p>Use shared documentation, usability research, training, and feedback loops to make complex capabilities easier for scientists and engineers to find, adopt, and use well.</p>
+    <div class="outcome-label">Outcome</div>
+    <div class="outcome-text">Less setup time; more time for discovery</div>
+  </div>
+  <div class="thrust">
+    <span class="thrust-code">06</span>
+    <h3>Plan for impact that lasts</h3>
+    <p>Apply product stewardship and impact frameworks to clarify users, adoption signals, maintenance needs, and transition paths beyond an initial Genesis milestone.</p>
+    <div class="outcome-label">Outcome</div>
+    <div class="outcome-text">A credible path from prototype to capability</div>
+  </div>
+</div>
+
+Ready to explore a collaboration? [Connect with PESO](/connect).

--- a/news.md
+++ b/news.md
@@ -6,8 +6,9 @@ section_tag: Updates
 permalink: /news
 ---
 
-<div class="log">
-{% for news in site.data.news %}
-<div class="log-row"><span class="log-date mono">{{ news.date }}</span><a href="{{ news.link }}">{{ news.title }}</a></div>
-{% endfor %}
+Browse PESO news by type:
+
+<div class="connect-grid" style="margin-top:8px; grid-template-columns:repeat(2,1fr); max-width:700px;">
+  <a class="connect-card" href="/news/events"><span class="tag">Events</span><h4>Conferences, meetings &amp; talks</h4><p>PI meetings, BOF days, conference presence at SC and CSE, and other PESO appearances.</p></a>
+  <a class="connect-card" href="/news/documents"><span class="tag">Documents</span><h4>Reports, releases &amp; resources</h4><p>Annual reports, E4S release notes, papers, and other PESO publications.</p></a>
 </div>

--- a/news/documents.md
+++ b/news/documents.md
@@ -1,0 +1,15 @@
+---
+title: Documents
+description: Annual reports, E4S release notes, papers, and other PESO publications.
+section_tag: Updates
+layout: page
+permalink: /news/documents
+---
+
+<div class="log">
+{% for item in site.data.news %}
+{% if item.category == 'document' %}
+<div class="log-row"><span class="log-date mono">{{ item.date }}</span><a href="{{ item.link }}">{{ item.title }}</a></div>
+{% endif %}
+{% endfor %}
+</div>

--- a/news/events.md
+++ b/news/events.md
@@ -1,0 +1,15 @@
+---
+title: Events
+description: PI meetings, BOF days, conference presence, and other PESO appearances.
+section_tag: Updates
+layout: page
+permalink: /news/events
+---
+
+<div class="log">
+{% for item in site.data.news %}
+{% if item.category == 'event' %}
+<div class="log-row"><span class="log-date mono">{{ item.date }}</span><a href="{{ item.link }}">{{ item.title }}</a></div>
+{% endif %}
+{% endfor %}
+</div>


### PR DESCRIPTION
- News split into a hub page plus /news/events and /news/documents, both reachable via a new News submenu.
- Fixed a real dropdown-hover bug (margin-based gap dropped the :hover state before reaching the menu) and a related CSS specificity bug affecting card/list styling on /connect, /thrusts, and the new News pages.
- New /genesis-mission page built from the "Where PESO Can Contribute" one-pager, with the nav's top-right pill now reading "PESO for Genesis Mission" — verified to fit on mobile down to 375px.

See the commit message for full detail. Verified with a full Jekyll build and manual/DOM-measurement browser passes throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)