### PR TITLE
Rename E4S long-form: Extreme-Scale Scientific Software Stack -> Ecosystem for Science

### DIFF
--- a/_data/thrusts.yml
+++ b/_data/thrusts.yml
@@ -31,10 +31,10 @@
     practical applications.
 
 - code: E4S
-  title: Extreme-scale Scientific Software Stack
+  title: Ecosystem for Science
   summary: A curated, tested software stack ready to run on DOE systems.
   description: >
-    The Extreme-scale Scientific Software Stack (E4S) provides a curated collection of HPC
+    The Ecosystem for Science (E4S) provides a curated collection of HPC
     software, ensuring easy access and deployment across different computing environments,
     with a focus on scalability and reproducibility.
   link: /engage/e4s

--- a/about/details.md
+++ b/about/details.md
@@ -12,7 +12,7 @@ Through collaborations, PESO provides:
 
 - **Software stacks and infrastructure** — testing, hardening, integration, distribution, and intermediate user support for a product, whether as its final destination, an early-access staging environment for pre-release versions, or both:
   - **Spack** — assistance creating and expanding [Spack](https://spack.io) capabilities for product build, testing, integration, and distribution.
-  - **E4S** — support for product integration and distribution in the Extreme-scale Scientific Software Stack ([E4S](https://e4s.io)), depending on a team's distribution strategy.
+  - **E4S** — support for product integration and distribution in the Ecosystem for Science ([E4S](https://e4s.io)), depending on a team's distribution strategy.
   - **CI** — continuous integration testing on a variety of commodity and emerging target vendor hardware/software stacks.
   - **Software quality improvement** — assistance improving product compatibility with E4S community policies.
 - **Stakeholder engagement** — opportunities for software teams and communities to engage with DOE, vendors, application communities, and cross-lab management.

--- a/engage/spack.md
+++ b/engage/spack.md
@@ -15,4 +15,4 @@ description: Spack - What and Why
 - **Reproducibility:** Reproducible builds, consistent setups across users & systems.
 - **Integration with CI/CD:** Integrates with CI/CD, enabling automated testing/deployment
 - **Community-Driven:** Maintained and extended by a large and active community
-- **E4S Integration:** Spack helps manage and deploy the Extreme-scale Scientific Software Stack (E4S), a curated collection of scientific libraries and tools, making it easier to get started with and maintain a robust HPC software environment.
+- **E4S Integration:** Spack helps manage and deploy the Ecosystem for Science (E4S), a curated collection of scientific libraries and tools, making it easier to get started with and maintain a robust HPC software environment.

--- a/sc24.md
+++ b/sc24.md
@@ -10,7 +10,7 @@ permalink: /sc24
 
 ### E4S 24.11 Release
 
-The PESO Project and the E4S team are happy to announce Release 24.11 of the Extreme-Scale Scientific Software Stack:
+The PESO Project and the E4S team are happy to announce Release 24.11 of the Ecosystem for Science:
 - [Release summary](https://pesoproject.org/files/PesoE4SAnnouncement.pdf){: .text-pink-500 underline}
 - [Full release notes](https://oaciss.uoregon.edu/e4s/talks/E4S_24.11.pdf){: .text-pink-500 underline}
 - [Download information](https://e4s-project.github.io/download.html){: .text-pink-500 underline}
@@ -21,5 +21,5 @@ Day/Time<br>(EST time zone) | Event Type | Event Title (see linked program page 
 :---     |    :------ |--------------------------------------------------------
 Mon. Nov. 18<br>8:00 pm - 9:00 pm | Booth chat | [The PESO Project at SC24, Session 1](https://pesoproject.org/files/PesoAtSc24.pdf){: .text-pink-500 underline}
 Tue. Nov. 19<br>10:00 am - 11:00 am | Booth chat | [The PESO Project at SC24, Session 2](https://pesoproject.org/files/PesoAtSc24.pdf){: .text-pink-500 underline}
-Tue. Nov. 19<br>12:00 pm - 1:00 pm | Booth chat | [E4S: Extreme-scale Scientific Software Stack, Session 1](https://pesoproject.org/files/PesoE4SAnnouncement.pdf){: .text-pink-500 underline}
-Tue. Nov. 19<br>3:00 pm - 4:00 pm | Booth chat | [E4S: Extreme-scale Scientific Software Stack, Session 2](https://pesoproject.org/files/PesoE4SAnnouncement.pdf){: .text-pink-500 underline}
+Tue. Nov. 19<br>12:00 pm - 1:00 pm | Booth chat | [E4S: Ecosystem for Science, Session 1](https://pesoproject.org/files/PesoE4SAnnouncement.pdf){: .text-pink-500 underline}
+Tue. Nov. 19<br>3:00 pm - 4:00 pm | Booth chat | [E4S: Ecosystem for Science, Session 2](https://pesoproject.org/files/PesoE4SAnnouncement.pdf){: .text-pink-500 underline}


### PR DESCRIPTION
Replaces every spelled-out definition of E4S site-wide with "Ecosystem for Science," keeping the E4S acronym unchanged: _data/thrusts.yml, about/details.md, engage/spack.md, sc24.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)