### PR TITLE
Update hero copy with linked partner orgs; trim Engage page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
   <div class="wrap hero-inner">
     <div class="kicker">● DOE · Office of Science · ASCR</div>
     <h1 class="display">Stewarding the scientific software <span class="accent">stack</span></h1>
-    <p class="lede">PESO exists to preserve, sustain, and advance the investments made by the DOE Exascale Computing Project in a robust, versatile, and portable HPC software ecosystem — and the people who make that ecosystem effective. Partnership with CASS.</p>
+    <p class="lede">PESO exists to sustain and advance a robust, versatile, and portable HPC-AI software ecosystem and support the community of people who make that ecosystem effective. PESO sponsors the <a href="https://e4s.io">E4S</a> software Ecosystem for Science including hundreds of scientific libraries, tools, and applications, the <a href="https://spack.io">Spack</a> package management system for open science, and supports community engagement through the <a href="https://cass.community">Consortium for the Advancement of Scientific Software (CASS)</a> and the <a href="https://hpsf.io">High Performance Software Foundation (HPSF)</a>.</p>
     <p style="margin-top:14px; font-size:13.5px; color:#8296B4;">PIs: Michael Heroux &amp; Lois Curfman McInnes</p>
     <div class="hero-ctas">
       <a class="btn-primary" href="/connect">Connect with PESO</a>

--- a/assets/css/signal.css
+++ b/assets/css/signal.css
@@ -101,7 +101,9 @@ h1.display{
   max-width:780px; color:#fff;
 }
 h1.display .accent{color:var(--amber);}
-.hero p.lede{max-width:580px; margin-top:24px; font-size:17.5px; color:#C7D3E6; line-height:1.6;}
+.hero p.lede{max-width:640px; margin-top:24px; font-size:17.5px; color:#C7D3E6; line-height:1.6;}
+.hero p.lede a{color:var(--amber); font-weight:600; text-decoration:underline; text-underline-offset:2px; text-decoration-color:rgba(242,153,74,0.45);}
+.hero p.lede a:hover{color:#fff; text-decoration-color:#fff;}
 .hero-ctas{display:flex; gap:16px; margin-top:34px; flex-wrap:wrap;}
 .btn-primary{
   background:#fff; color:var(--navy); font-weight:700; font-size:15px;

--- a/engage.md
+++ b/engage.md
@@ -10,14 +10,6 @@ Scientific software is a critical component of the scientific discovery process.
 
 Software ecosystems offer economies of scales in a variety of ways. They can provide a platform for sharing and reusing software components, tools, and libraries. They can also provide a platform for collaboration and coordination among software developers, users, and stakeholders. By promoting the development and use of scientific software as an ecosystem, PESO aims to create a sustainable and vibrant community of software developers, users, and stakeholders who work together to advance the state of the art in scientific computing.
 
-The following links describes the promise of how investing in scientific software as an ecosystem can lead to a more productive and sustainable scientific discovery process for your organization:
-
-|**Topic** | **Description** | **Resources** |
-|-----------|----------------|--------------|
-|**Spack** | Spack: What and Why | [Spack](/engage/spack) |
-|**E4S** | E4S: What and Why | [E4S](/engage/e4s) |
-|**HPSF** | HPSF: What and Why | [HPSF](/engage/hpsf) |
-
 ## Powers of ten
 
 A summary of the benefits of the PESO-sponsored software ecosystem, at every scale:


### PR DESCRIPTION
- Hero lede replaced with copy naming what PESO sponsors/supports (E4S, Spack, CASS, HPSF), each linked and highlighted against the navy hero.
- Removed the redundant "following links" paragraph/table from /engage — those pages are already reachable via the Engage nav submenu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)