### PR TITLE
Replace "stack" with "ecosystem" in PESO ecosystem-framing copy

### DIFF
--- a/_data/thrusts.yml
+++ b/_data/thrusts.yml
@@ -32,7 +32,7 @@
 
 - code: E4S
   title: Ecosystem for Science
-  summary: A curated, tested software stack ready to run on DOE systems.
+  summary: A curated, tested software ecosystem ready to run on DOE systems.
   description: >
     The Ecosystem for Science (E4S) provides a curated collection of HPC
     software, ensuring easy access and deployment across different computing environments,

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
 <header class="hero">
   <div class="wrap hero-inner">
     <div class="kicker">● DOE · Office of Science · ASCR</div>
-    <h1 class="display">Stewarding the scientific software <span class="accent">stack</span></h1>
+    <h1 class="display">Stewarding the scientific software <span class="accent">ecosystem</span></h1>
     <p class="lede">PESO exists to sustain and advance a robust, versatile, and portable HPC-AI software ecosystem and support the community of people who make that ecosystem effective. PESO sponsors the <a href="https://e4s.io">Software Ecosystem for Science (E4S)</a> and the <a href="https://spack.io">Spack package management system</a> for open science. PESO contributes to community engagement through the <a href="https://cass.community">Consortium for the Advancement of Scientific Software (CASS)</a>, the <a href="https://bssw.io">Better Scientific Software (BSSW)</a> website and Fellowship program, and the <a href="https://hpsf.io">High Performance Software Foundation (HPSF)</a>.</p>
     <p style="margin-top:14px; font-size:13.5px; color:#8296B4;">PIs: Michael Heroux &amp; Lois Curfman McInnes</p>
     <div class="hero-ctas">

--- a/about.md
+++ b/about.md
@@ -18,7 +18,7 @@ PESO's vision is that DOE software investments will have maximum impact by provi
 
 Partnering with others, PESO will provide critical services and products that transform a broad collection of independently developed products by independent teams into a product portfolio whose total is much more than the sum of its parts. Furthermore, by working with product teams, users, stakeholders, computing facilities, other US agencies, and industry, we will provide a transition of activities from the DOE Exascale Computing Project (ECP) toward the goal of creating a software ecosystem that year over year will deliver high-quality, reliable, and trusted libraries and tools for DOE's mission-critical applications.
 
-ECP efforts have demonstrated that developing applications built on accelerator-optimized libraries and tools can improve scientific capabilities by two orders of magnitude or more, and that a trusted software stack is an essential element. PESO will provide the trusted software stack for applications to realize that 100X improvement — for high-end capabilities *and* for energy efficiency improvements that can be realized only by leveraging accelerator devices.
+ECP efforts have demonstrated that developing applications built on accelerator-optimized libraries and tools can improve scientific capabilities by two orders of magnitude or more, and that a trusted software ecosystem is an essential element. PESO will provide the trusted software ecosystem for applications to realize that 100X improvement — for high-end capabilities *and* for energy efficiency improvements that can be realized only by leveraging accelerator devices.
 
 ## Background
 

--- a/about/details.md
+++ b/about/details.md
@@ -27,7 +27,7 @@ PESO welcomes engagement at several levels:
 And with stakeholders and partners directly:
 
 - **Application teams**, coordinating delivery via E4S, containers, cloud, and facilities environments.
-- **DOE computing facilities**, providing and supporting a full stack of DOE-sponsored libraries and tools via E4S, in collaboration with commercial E4S partners.
+- **DOE computing facilities**, providing and supporting a full ecosystem of DOE-sponsored libraries and tools via E4S, in collaboration with commercial E4S partners.
 - **Computer system vendors**, ensuring DOE-sponsored libraries and tools are available as part of or complementary to vendor software.
 - **Commercial software providers**, co-developing and supporting DOE-sponsored software for industry, US agencies, and international partners.
 - **US agencies**, making DOE-sponsored software available to their users while assuring compatibility with their own software environments.

--- a/genesis-mission.md
+++ b/genesis-mission.md
@@ -9,7 +9,7 @@ permalink: /genesis-mission
 <div class="thrust-grid" style="margin-top:8px;">
   <div class="thrust">
     <span class="thrust-code">01</span>
-    <h3>Stand up a mission-ready software stack</h3>
+    <h3>Stand up a mission-ready software ecosystem</h3>
     <p>Turn a project's libraries, tools, and dependencies into a coherent, version-compatible environment using E4S and Spack — ready for repeatable science from day one.</p>
     <div class="outcome-label">Outcome</div>
     <div class="outcome-text">A documented, reproducible starting point</div>

--- a/thrusts.md
+++ b/thrusts.md
@@ -1,14 +1,14 @@
 ---
 layout: page
 title: PESO Project Thrusts
-description: Six parallel work areas, each shipping into the same shared scientific software stack.
+description: Six parallel work areas, each shipping into the same shared scientific software ecosystem.
 section_tag: Program structure
 permalink: /thrusts
 ---
 
 Efforts in the PESO Project are organized into six thrust areas, each focusing on a specific aspect of scientific software development and deployment in the context of advanced high-performance computing (HPC). These thrusts are designed to address key challenges and opportunities in the field, with the goal of advancing the state of the art in scientific computing and enabling researchers to leverage the full potential of HPC resources.
 
-They are parallel, not sequential — each ships independently into the same shared stack.
+They are parallel, not sequential — each ships independently into the same shared ecosystem.
 
 <div class="thrust-grid" style="margin-top:8px;">
 {% for t in site.data.thrusts %}


### PR DESCRIPTION
Audited every use of "stack" site-wide and replaced it where it described PESO's own mission/ecosystem in its own voice (homepage headline, thrusts.md, thrusts.yml, about.md, about/details.md, genesis-mission.md), for consistency with the site's ecosystem framing and the earlier E4S rename to "Ecosystem for Science."

Kept "stack" where it's a technically precise term (build/hardware configurations, poster metadata) or another organization's own stated language (HPSF's mission paraphrase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)