### PR TITLE
Site review fixes: nav, Genesis Mission, team, details, thrusts, Frank, Spack/E4S

### DIFF
--- a/_data/thrusts.yml
+++ b/_data/thrusts.yml
@@ -4,7 +4,9 @@
   description: >
     Focuses on integrating diverse software components into a cohesive ecosystem that supports
     advanced scientific computing, ensuring compatibility and optimized performance across
-    various platforms.
+    various platforms. This work is carried out through the CASS <a href="https://cass.community/working-groups/software-ecosystem.html">Software Ecosystem</a>
+    and <a href="https://cass.community/working-groups/integration.html">Integration</a> working groups, alongside HPSF's integration working
+    group and the shared Frank cluster at the University of Oregon, used for porting and CI testing.
 
 - code: UDX
   title: User-Developer Experience
@@ -12,7 +14,7 @@
   description: >
     Aims to enhance the interaction between users and developers, improving the usability and
     efficiency of software tools while fostering a collaborative environment for ongoing
-    development.
+    development. This work is carried out through the CASS <a href="https://cass.community/working-groups/user-developer-experience.html">User-Developer Experience</a> working group.
 
 - code: COMM
   title: Community Engagement
@@ -20,7 +22,7 @@
   description: >
     Strengthens the involvement of the scientific community by fostering collaborations,
     disseminating best practices, and supporting open-source contributions to ensure the
-    sustainability and evolution of the software ecosystem.
+    sustainability and evolution of the software ecosystem. This work is carried out through the CASS <a href="https://cass.community/working-groups/workforce.html">Workforce</a> working group.
 
 - code: IMPACT
   title: Impact Frameworks
@@ -28,22 +30,20 @@
   description: >
     Develops methodologies and tools to measure and maximize the impact of software on
     scientific research, ensuring that contributions lead to significant advancements and
-    practical applications.
+    practical applications. This work is carried out through the CASS <a href="https://cass.community/working-groups/impact-framework.html">Impact Framework</a> working group.
 
 - code: E4S
   title: Ecosystem for Science
   summary: A curated, tested software ecosystem ready to run on DOE systems.
   description: >
-    The Ecosystem for Science (E4S) provides a curated collection of HPC
-    software, ensuring easy access and deployment across different computing environments,
-    with a focus on scalability and reproducibility.
+    A curated, tested software ecosystem ready to run on DOE systems — see e4s.io for the
+    full product catalog and documentation.
   link: /engage/e4s
 
 - code: SPACK
   title: Spack
   summary: The package manager that builds and delivers the whole ecosystem.
   description: >
-    A package manager designed to support the building and deployment of scientific software
-    across diverse platforms, Spack is critical for managing complex dependencies and ensuring
-    the portability and consistency of software installations across HPC environments.
+    The package manager that builds and delivers the whole ecosystem — see spack.io for
+    documentation and tutorials.
   link: /engage/spack

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,8 @@
+{% capture issue_title %}Feedback on: {{ page.title | default: site.title }}{% endcapture %}
+{% capture issue_body %}Page: {{ site.url | default: "https://pesoproject.org" }}{{ page.url }}
+
+<!-- Describe what you'd like to see changed or fixed on this page. -->
+{% endcapture %}
 <div class="wrap">
     <div class="footer-links">
         <a href="/about">About</a>
@@ -11,6 +16,7 @@
         <a href="/news/events">Events</a>
         <a href="/news/documents">Documents</a>
         <a href="/connect">Connect</a>
+        <a href="https://github.com/pesoproject/pesoproject.github.io/issues/new?title={{ issue_title | url_encode }}&amp;body={{ issue_body | url_encode }}" target="_blank" rel="noopener">Report an issue with this page</a>
     </div>
     <span class="mono">© {{ site.time | date: '%Y' }} The PESO Project</span>
     <a href="https://science.osti.gov/ascr" target="_blank" rel="noopener">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -30,6 +30,7 @@
           <div class="submenu-panel">
             <a href="/engage/spack">Spack</a>
             <a href="/engage/e4s">E4S</a>
+            <a href="/engage/frank">Frank</a>
             <a href="/engage/cass">CASS</a>
             <a href="/engage/bssw">BSSw</a>
             <a href="/engage/hpsf">HPSF</a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,6 @@
   <div class="wrap">
     <a class="brand" href="/">
       <img src="/images/peso-logo-no-bg.png" alt="PESO">
-      <span>PESO</span>
     </a>
 
     <div class="navlinks" id="navlinks">

--- a/about/details.md
+++ b/about/details.md
@@ -1,50 +1,33 @@
 ---
 title: PESO Project Details
-description: How PESO operates, its guiding principles, and its key activities.
+description: How PESO is organized and funded, how it works with CASS, and where it's headed next.
 section_tag: About PESO
 layout: page
 permalink: /about/details
 ---
 
-## How we work
+PESO is a five-year software-ecosystem stewardship and advancement project, advancing the DOE Office of Advanced Scientific Computing Research (ASCR) scientific software ecosystem by coordinating stewardship, integration, and quality-focused activities across a diverse portfolio of DOE-funded software projects.
 
-Through collaborations, PESO provides:
+## How PESO is organized and funded
 
-- **Software stacks and infrastructure** — testing, hardening, integration, distribution, and intermediate user support for a product, whether as its final destination, an early-access staging environment for pre-release versions, or both:
-  - **Spack** — assistance creating and expanding [Spack](https://spack.io) capabilities for product build, testing, integration, and distribution.
-  - **E4S** — support for product integration and distribution in the Ecosystem for Science ([E4S](https://e4s.io)), depending on a team's distribution strategy.
-  - **CI** — continuous integration testing on a variety of commodity and emerging target vendor hardware/software stacks.
-  - **Software quality improvement** — assistance improving product compatibility with E4S community policies.
-- **Stakeholder engagement** — opportunities for software teams and communities to engage with DOE, vendors, application communities, and cross-lab management.
-- **An annual all-teams workshop** — bringing together product teams, stakeholders, and other key parties for planning and coordination.
+PESO's annual budget is $4M, supporting about 40 staff members at 8 DOE labs, four industry partners, and one university. By design, many PESO team members also receive funding from partner software stewardship organizations (SSOs), enabling close coordination and reducing duplication of effort across the CASS portfolio. Roughly 75 percent of PESO's budget funds cross-SSO collaboration:
 
-PESO welcomes engagement at several levels:
+- **Technical collaborations** (~54%) — strengthening interoperability, testing, and infrastructure among SSOs, organized into PESO's [six thrusts](/thrusts).
+- **Spack and E4S** (~25%) — direct support for the two cornerstone PESO products that deliver and curate the DOE Office of Science's software portfolio.
+- **Community and outreach collaborations** (~21%) — promoting visibility and broad adoption of DOE scientific libraries and tools, and workforce development.
 
-- **Individual product teams** whose products would benefit DOE application users and facilities — ideally also participating in a compatible product community, typically a DOE-sponsored software stewardship organization (SSO).
-- **Software product communities ("spokes")** — new and established communities that define their own quality-driving policies, ideally compatible with E4S community policies where products distribute through E4S.
-- **Communities of practice** organized around cross-cutting concerns — research software engineering training (e.g., [IDEAS](https://ideas-productivity.org)), community outreach (e.g., [CSCCE](https://cscce.org) strategies), software foundations (e.g., [NumFOCUS](https://numfocus.org), [Linux Foundation](https://www.linuxfoundation.org)), and workforce development (e.g., [US RSE](https://us-rse.org), [BSSw Fellows](https://bssw.io/fellowship), [Sustainable Research Pathways](https://bssw.io/events/sustainable-research-pathways-srp)).
+## How we work with CASS
 
-And with stakeholders and partners directly:
+Through collaborations within the [Consortium for the Advancement of Scientific Software (CASS)](/engage/cass), PESO provides shared infrastructure, coordination, and stewardship practices that improve interoperability, quality, and adoption across a diverse software portfolio spanning applied math (FASTMath), AI/data/visualization (RAPIDS), programming models and runtimes (S4PST), and tools for performance and correctness (STEP). These activities are designed to complement — not replace — product-level stewardship by individual teams and SSOs.
 
-- **Application teams**, coordinating delivery via E4S, containers, cloud, and facilities environments.
-- **DOE computing facilities**, providing and supporting a full ecosystem of DOE-sponsored libraries and tools via E4S, in collaboration with commercial E4S partners.
-- **Computer system vendors**, ensuring DOE-sponsored libraries and tools are available as part of or complementary to vendor software.
-- **Commercial software providers**, co-developing and supporting DOE-sponsored software for industry, US agencies, and international partners.
-- **US agencies**, making DOE-sponsored software available to their users while assuring compatibility with their own software environments.
+PESO leads or significantly staffs several CASS working groups, including Software Ecosystem, Integration, Impact Framework, Software Quality Assurance, and User-Developer Experience — the same five thrusts detailed on the [Thrusts](/thrusts) page. A CASS-wide Impact Framework, developed and led by PESO, gives the consortium a common, transparent way to track software stewardship activities and progress across the whole portfolio.
 
-## Principles
+## Looking forward: AI and the Genesis Mission
 
-- **Transparency** — open governance policies and open access to Consortium artifacts.
-- **Diversity** — cultivation of diverse participation and representation.
-- **Sustainability** — long-term viability and growth of software, practices, and workforce.
-- **Innovation** — responsiveness to stakeholder needs and technological evolution.
-- **Cooperation** — working together to support the overall Consortium mission.
-- **Integrity** — acting as a fair, trusted, and respected asset to the community.
+PESO is positioning the scientific software ecosystem to support AI-for-Science workflows, including emerging world-model approaches that combine data-driven methods with equation-based simulation components. Rather than treating AI as a standalone activity, PESO integrates AI considerations into ecosystem stewardship — emphasizing reproducibility, software quality, usability, and interoperability as AI becomes a central element of scientific discovery. This work aligns directly with DOE's Genesis Mission, which calls for rapid increases in scientific productivity through the convergence of simulation, data, and AI. See [how PESO can help Genesis Mission teams](/genesis-mission).
 
-## Key activities
+## Community and outreach
 
-- **Partnerships** — leading efforts to foster a diverse and inclusive workforce with sustainable career paths; shepherding the Better Scientific Software Fellows Program and contributing to the leadership of the [BSSw.io](https://bssw.io) web portal.
-- **Services** — software product management, integration, and delivery, plus software quality assurance and security.
-- **Products** — delivery and support via Spack and E4S, including porting and testing platforms shared across product teams to ensure code stability and portability, and facilitating delivery of other products such as AI/ML libraries as needed by the HPC community.
+PESO supports leadership for the CASS Steering Committee and multiple working groups, and staffs a range of cross-SSO initiatives that cultivate the scientific software workforce and public visibility — including the [Better Scientific Software (BSSw) program](/engage/bssw) and the [High Performance Software Foundation (HPSF)](/engage/hpsf). See the [CASS](/engage/cass) page for PESO's specific leadership roles across the consortium.
 
 Want to be part of this? See how to [connect with PESO](/connect) or meet the [team](/about/team).

--- a/about/team.md
+++ b/about/team.md
@@ -10,31 +10,54 @@ permalink: /about/team
 | --- | --- | --- |
 | Michael Heroux | ParaTools, Inc. | PI |
 | Lois Curfman McInnes | Argonne National Laboratory | PI |
-| Todd Gamblin | Lawrence Livermore National Laboratory | Spack Lead |
-| Sameer Shende | University of Oregon | E4S Lead |
-| James Willenbring | Sandia National Laboratories | Integration Lead |
+| David Bernholdt | Oak Ridge National Laboratory | Senior Leader |
+| Todd Gamblin | Lawrence Livermore National Laboratory | Senior Leader |
+| Sameer Shende | University of Oregon | Senior Leader |
+| James Willenbring | Sandia National Laboratories | Senior Leader |
 | Satish Balay | Argonne National Laboratory | |
+| Cody Balos | Lawrence Livermore National Laboratory | |
 | Roscoe Bartlett | Sandia National Laboratories | |
 | Keith Beattie | Lawrence Berkeley National Laboratory | |
-| Greg Becker | Lawrence Livermore National Laboratory | |
-| David Bernholdt | Oak Ridge National Laboratory | |
-| Tamara Dahlgren | Lawrence Livermore National Laboratory | |
+| Jakob Bludau | Oak Ridge National Laboratory | |
+| Vicente Bolea | Kitware, Inc. | |
+| Sam Browne | Sandia National Laboratories | |
+| Hannah Cohoon | Lawrence Berkeley National Laboratory | |
 | Berk Geveci | Kitware, Inc. | |
 | William Godoy | Oak Ridge National Laboratory | |
 | Elsa Gonsiorowski | Lawrence Livermore National Laboratory | |
 | Patricia Grubel | Los Alamos National Laboratory | |
+| Dan Gunter | Lawrence Berkeley National Laboratory | |
+| Rinku Gupta | Argonne National Laboratory | |
+| Tim Haines | Kitware, Inc. | |
 | Mahantesh Halappanavar | Pacific Northwest National Laboratory | |
 | Bill Hoffman | Kitware, Inc. | |
+| Ryan Krattiger | Kitware, Inc. | |
+| Adam Lavely | Lawrence Berkeley National Laboratory | |
 | Damien Lebrun-Grandie | Oak Ridge National Laboratory | |
 | Mary Ann Leung | Sustainable Horizons Institute | |
 | Xiaoye Sherry Li | Lawrence Berkeley National Laboratory | |
-| Dan Martin | Lawrence Berkeley National Laboratory | |
-| Mark Miller | Lawrence Livermore National Laboratory | |
+| Daniel Martin | Lawrence Berkeley National Laboratory | |
+| Caetano Melone | Lawrence Livermore National Laboratory | |
+| Erdal Mutlu | Pacific Northwest National Laboratory | |
 | Patrick O'Leary | Kitware, Inc. | |
-| Erik Palmer | Lawrence Berkeley National Laboratory | |
 | Suzanne Parete-Koon | Oak Ridge National Laboratory | |
-| Lavanya Ramakrishnan | Lawrence Berkeley National Laboratory | |
+| Drew Paine | Lawrence Berkeley National Laboratory | |
+| Jeff Sharpe | Sandia National Laboratories | |
 | Rajeev Thakur | Argonne National Laboratory | |
-| Matteo Turilli | Brookhaven National Laboratory | |
+| Mikhail Titov | Brookhaven National Laboratory | |
 | Terece Turton | Los Alamos National Laboratory | |
 | Hui Zhou | Argonne National Laboratory | |
+
+The CASS User-Developer Experience (UDX) Working Group is co-led by **Hannah Cohoon** and **Drew Paine** (both Lawrence Berkeley National Laboratory).
+
+## PESO Alumni
+
+| **Team Member** | **Affiliation** |
+| --- | --- |
+| Erik Palmer | Lawrence Berkeley National Laboratory |
+| Tamara Dahlgren | Lawrence Livermore National Laboratory |
+| Ulrike Meier Yang | Lawrence Livermore National Laboratory |
+| Mark Miller | Lawrence Livermore National Laboratory |
+| Gregory Becker | Lawrence Livermore National Laboratory |
+| Matteo Turilli | Brookhaven National Laboratory |
+| Lavanya Ramakrishnan | Lawrence Berkeley National Laboratory |

--- a/assets/css/signal.css
+++ b/assets/css/signal.css
@@ -34,8 +34,7 @@ img{max-width:100%;}
 nav.site-nav{position:sticky; top:0; z-index:30; background:rgba(14,35,64,0.94); backdrop-filter:blur(8px);}
 nav.site-nav .wrap{display:flex; align-items:center; justify-content:space-between; height:72px; gap:20px;}
 .brand{display:flex; align-items:center; gap:10px; text-decoration:none;}
-.brand img{height:24px; width:auto; filter:brightness(0) invert(1);}
-.brand span{font-family:'Space Grotesk',sans-serif; font-weight:700; font-size:19px; color:#fff; letter-spacing:-0.01em;}
+.brand img{height:32px; width:auto; filter:brightness(0) invert(1);}
 
 .navlinks{display:flex; align-items:center; gap:32px; font-size:14.5px; color:#B7C4DA; flex:1;}
 .navlinks a{text-decoration:none; transition:color .15s;}

--- a/connect.md
+++ b/connect.md
@@ -8,8 +8,7 @@ permalink: /connect
 
 Any member of the computational science and engineering community with an interest in improving the stewardship of scientific software is encouraged to engage with PESO. We're particularly interested in contributions that address usability, sustainability, and overall quality of leadership scientific software — gaps, requirements, areas for exploration, or working approaches from other software communities are all welcome.
 
-<div class="connect-grid" style="margin-top:32px;">
+<div class="connect-grid" style="margin-top:32px; grid-template-columns:repeat(2,1fr); max-width:700px;">
   <a class="connect-card" href="https://docs.google.com/forms/d/e/1FAIpQLSdvbp-0Qou_Y0yFUsgV9nyNludJfY2kJn5s0ZkoFcz13Nj0rg/viewform" target="_blank" rel="noopener"><span class="tag">Form</span><h4>Tell us about yourself</h4><p>Share your interests in scientific software stewardship.</p></a>
-  <a class="connect-card" href="https://pesoproject.org" target="_blank" rel="noopener"><span class="tag">Subscribe</span><h4>Join the mailing list</h4><p>Hear about events and news from the PESO Project.</p></a>
   <a class="connect-card" href="mailto:help@pesoproject.org"><span class="tag">Email</span><h4>help@pesoproject.org</h4><p>Start a conversation with PESO leadership.</p></a>
 </div>

--- a/engage/e4s.md
+++ b/engage/e4s.md
@@ -5,13 +5,12 @@ title: E4S - What and Why
 description: E4S - What and Why
 ---
 
-[E4S](https://e4s.io) provides 140+ HPC-AI libraries and tools, easing deployment, management, and reproducibility of complex scientific workflows.
+[E4S](https://e4s.io) is one of PESO's two cornerstone software products: a curated, version-compatible portfolio of DOE-relevant scientific libraries and tools, built with [Spack](/engage/spack) and validated through ecosystem-level continuous integration and interoperability testing.
 
-- **Comprehensive Software Portfolio:** Curated collection of HPC and AI libraries & tools
-- **Cross-Platform Compatibility:** All major & emerging HPC platforms, desktops to supercomputers
-- **Ease of Installation via curated Spack configuration:** Spack with ensured compatibility, tested, and optimize environment
-- **Focus on Reproducibility:** Standardized deployment on many systems, for validation & collaboration
-- **Continuous Integration & Testing:** On many platforms including latest CPUs, APUs, and GPUs
-- **Support for Modern Workflows:** Support for parallel, GPU acceleration, and cloud-native apps
-- **Community and Industry Collaboration:** Maintained via national labs, academia, industry, collaborations
-- **Documentation and Support:** Comprehensive resources, aiding effective deployment & utilization
+- **Scale:** The E4S 25.11 release curates 125 primary products and hundreds of dependencies, spanning traditional HPC workloads and AI-enabled scientific workflows.
+- **A shared integration environment:** Software stewarded across FASTMath, RAPIDS, S4PST, STEP, CORSA, and PESO is built and tested together under representative configurations, rather than in isolation.
+- **A real destination, not just a list:** The E4S website, Learning Portal, and Quickstart Guide are core PESO deliverables — the primary place users, facility staff, developers, and vendors go for documentation and support.
+
+**PESO's role in E4S.** E4S curation is coordinated directly with CASS governance and working groups — Integration, Software Quality Assurance, Impact Framework, Metrics, and User-Developer Experience — with PESO personnel participating so that packaging decisions stay aligned with the ecosystem's broader goals. PESO also coordinates E4S availability with American Science Cloud (AmSC) leadership. **Sameer Shende** (University of Oregon) leads E4S under PESO.
+
+Learn more or browse the product catalog at [e4s.io](https://e4s.io).

--- a/engage/frank.md
+++ b/engage/frank.md
@@ -1,0 +1,14 @@
+---
+section_tag: Engage with PESO
+layout: page
+title: Frank - What and Why
+description: Frank - What and Why
+---
+
+Frank — informally "Frankenstein" — is a multi-node cluster at the University of Oregon that PESO supports as a shared resource for the CASS community.
+
+- **Porting to modern devices:** Frank gives software teams access to current and emerging accelerator hardware for porting applications and libraries to new devices, without every team needing to acquire and maintain its own.
+- **Continuous integration:** Frank runs a substantial share of ecosystem-wide CI testing, including for [HPSF](/engage/hpsf) projects, providing GPU resources that would otherwise be costly or impractical for individual teams to run on their own.
+- **A shared, cost-effective resource:** Because Frank is shared across many CASS software teams, it reduces the cost and effort of standing up and maintaining dedicated test hardware project by project.
+
+Hardware specifics, supported architectures, and access details change over time — see [e4s.io](https://e4s.io) for the latest information.

--- a/engage/spack.md
+++ b/engage/spack.md
@@ -5,14 +5,12 @@ title: Spack - What and Why
 description: Spack - What and Why
 ---
 
-[Spack](https://spack.io) supports teams managing a diverse, evolving set of libraries and tools across various HPC systems, ensuring consistent, reliable, and reproducible software environments.
+[Spack](https://spack.io) is the de facto standard for software delivery across the HPC ecosystem, giving teams a single tool to manage software complexity from laptops to leadership-class systems. Originally developed under the NNSA Advanced Simulation and Computing program and adopted as the primary integration tool during the DOE Exascale Computing Project, Spack is now a founding project of the [High Performance Software Foundation (HPSF)](/engage/hpsf) and a foundational component of the CASS ecosystem.
 
-- **Flexible Package Management:** Install multiple versions & configs side by side without conflicts
-- **Cross-Platform Support :** Wide range of HPC architectures: laptops, clusters, supercomputers
-- **Dependency Resolution:** Automatically handles complex dependency chains
-- **Customizable Builds:** Modifiable build options, compiler choices, & dependency versions
-- **Extensive Repository:** Thousands of packages: a wide range of scientific-AI software
-- **Reproducibility:** Reproducible builds, consistent setups across users & systems.
-- **Integration with CI/CD:** Integrates with CI/CD, enabling automated testing/deployment
-- **Community-Driven:** Maintained and extended by a large and active community
-- **E4S Integration:** Spack helps manage and deploy the Ecosystem for Science (E4S), a curated collection of scientific libraries and tools, making it easier to get started with and maintain a robust HPC software environment.
+- **Scale:** A community-maintained repository of more than 8,600 package recipes, backed by cloud-hosted build and test infrastructure that runs over 100,000 builds per week across Amazon Web Services and the University of Oregon's [Frank cluster](/engage/frank).
+- **A 1.0 milestone:** Spack reached its 1.0 release in FY2025, with follow-on releases addressing facility-specific challenges such as compiler mixing and expanded binary compatibility.
+- **The foundation for E4S:** Spack is the packaging technology [E4S](/engage/e4s) is built on.
+
+**PESO's role in Spack.** NNSA supports the foundational development of Spack's core technology; PESO's investment is distinct, directing Spack's capabilities toward ASCR-specific integration challenges, open-science facility deployment, and the interoperability the CASS ecosystem depends on. PESO provides the stewardship infrastructure that turns contributions from thousands of DOE scientists into a reliable, tested software stack, and works closely with CASS software teams to ensure the features they need are supported in Spack. **Todd Gamblin** (Lawrence Livermore National Laboratory) leads Spack under PESO.
+
+Learn more, browse packages, or get involved at [spack.io](https://spack.io).

--- a/genesis-mission.md
+++ b/genesis-mission.md
@@ -1,32 +1,36 @@
 ---
 layout: page
-title: Make the software between the breakthroughs work.
-description: Genesis Mission teams are connecting AI, advanced computing, experiments, and data at unprecedented scale — PESO helps turn that underlying software into a coherent, reliable, sustainable ecosystem, so teams spend less time assembling infrastructure and more time accelerating discovery.
+title: Make the software behind the breakthroughs work.
+description: Genesis Mission teams are connecting AI, advanced computing, experiments, and data at unprecedented scale — PESO builds and hardens the underlying software into a coherent, reliable, sustainable ecosystem, so teams spend less time assembling infrastructure and more time accelerating discovery.
 section_tag: DOE Genesis Mission Teams
 permalink: /genesis-mission
 ---
+
+For nearly three years, PESO has stewarded a portfolio of DOE-funded software — including the E4S and Spack ecosystems — improving how tools across the DOE Office of Science are packaged, integrated, tested, documented, and connected across leadership computing facilities. That foundation is directly relevant to Genesis Mission teams standing up new AI-for-science capabilities on a tight timeline, and PESO is eager to work alongside Genesis Mission projects from the outset.
+
+PESO takes a multifaceted approach in the following ways:
 
 <div class="thrust-grid" style="margin-top:8px;">
   <div class="thrust">
     <span class="thrust-code">01</span>
     <h3>Stand up a mission-ready software ecosystem</h3>
-    <p>Turn a project's libraries, tools, and dependencies into a coherent, version-compatible environment using E4S and Spack — ready for repeatable science from day one.</p>
+    <p>Package a project's libraries, tools, and dependencies into a coherent, version-compatible environment using E4S and Spack — ready for repeatable science from day one.</p>
     <div class="outcome-label">Outcome</div>
     <div class="outcome-text">A documented, reproducible starting point</div>
   </div>
   <div class="thrust">
     <span class="thrust-code">02</span>
-    <h3>De-risk deployment across facilities</h3>
-    <p>Work through portability issues across leadership systems, accelerators, clusters, cloud-adjacent platforms, and emerging architectures before they slow the science.</p>
-    <div class="outcome-label">Outcome</div>
-    <div class="outcome-text">Fewer platform surprises and faster onboarding</div>
-  </div>
-  <div class="thrust">
-    <span class="thrust-code">03</span>
     <h3>Build an integration &amp; assurance lane</h3>
     <p>Add ecosystem-level continuous integration, compatibility testing, software quality practices, and supply-chain security to catch failures at the seams between products.</p>
     <div class="outcome-label">Outcome</div>
     <div class="outcome-text">Trusted releases with visible evidence</div>
+  </div>
+  <div class="thrust">
+    <span class="thrust-code">03</span>
+    <h3>De-risk deployment across facilities</h3>
+    <p>Resolve portability issues across leadership systems, accelerators, clusters, cloud-adjacent platforms, and emerging architectures before they slow the science.</p>
+    <div class="outcome-label">Outcome</div>
+    <div class="outcome-text">Fewer platform surprises and faster onboarding</div>
   </div>
   <div class="thrust">
     <span class="thrust-code">04</span>
@@ -45,7 +49,7 @@ permalink: /genesis-mission
   <div class="thrust">
     <span class="thrust-code">06</span>
     <h3>Plan for impact that lasts</h3>
-    <p>Apply product stewardship and impact frameworks to clarify users, adoption signals, maintenance needs, and transition paths beyond an initial Genesis milestone.</p>
+    <p>Apply product stewardship and impact frameworks to clarify users, adoption signals, maintenance needs, and transition paths beyond an initial Genesis milestone — built to grow as AI capabilities, and the software they depend on, keep advancing quickly.</p>
     <div class="outcome-label">Outcome</div>
     <div class="outcome-text">A credible path from prototype to capability</div>
   </div>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ permalink: /
   <div class="wrap">
     <div>
       <h2>Connect with PESO</h2>
-      <p>Share your interests, join the mailing list, or start a conversation with PESO leadership.</p>
+      <p>Share your interests or start a conversation with PESO leadership.</p>
     </div>
     <a class="btn-primary" href="/connect">Get involved →</a>
   </div>


### PR DESCRIPTION
Batch of fixes from a full-site review:

- Remove redundant "PESO" wordmark from the nav brand (logo only)
- Add a per-page "Report an issue" link to the footer
- Drop the mailing-list card from the Connect page (no mailing list exists)
- Rebuild the Team page from PesoTeamMemberInfo.xlsx, expanding lab acronyms to full names, adding an Alumni section
- Rewrite Project Details from the 2025 PESO Project Report, removing stale/inconsistent terminology
- Link the first four Thrusts to their corresponding CASS working groups; mention HPSF's integration group and the Frank cluster
- Add a new Engage page for the Frank cluster, pointing to e4s.io for details that would go stale
- Rewrite the Spack and E4S engage pages to match the "what it is / PESO's role" pattern used for CASS/BSSw/HPSF, replacing generic marketing bullet lists
- Revise the Genesis Mission page copy per PI review: retitle, tighten language, reorder tiles, add framing copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)