### PR TITLE
Soften Problem Space title wording

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
 <div class="wrap">
     <div class="footer-links">
         <a href="/about">About</a>
-        <a href="/about/problem-space">Problem Space</a>
+        <a href="/about/problem-space">Problem PESO Addresses</a>
         <a href="/about/details">Project Details</a>
         <a href="/about/team">Team</a>
         <a href="/thrusts">Thrusts</a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -12,7 +12,7 @@
         </button>
         <div class="submenu">
           <div class="submenu-panel">
-            <a href="/about/problem-space">Problem Space</a>
+            <a href="/about/problem-space">Problem PESO Addresses</a>
             <a href="/about/details">Project Details</a>
             <a href="/about/team">Team</a>
           </div>

--- a/about/problem-space.md
+++ b/about/problem-space.md
@@ -1,6 +1,6 @@
 ---
-title: The Problem PESO Solves
-title_html: The Problem <span class="accent">PESO</span> Solves
+title: The Problem PESO Addresses
+title_html: The Problem <span class="accent">PESO</span> Addresses
 description: The failure modes PESO exists to fix, and how the ecosystem approach resolves them.
 section_tag: About PESO
 layout: page


### PR DESCRIPTION
Replaces "Solves" with "Addresses" in the Problem Space page title,
the About dropdown label, and the footer link, per feedback that
"Solves" read a bit strong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)